### PR TITLE
Support MPI_THREAD_MULTIPLE

### DIFF
--- a/src/mg_tp.h
+++ b/src/mg_tp.h
@@ -46,6 +46,7 @@
 #  endif
 
 #  define CALL_MPI_Init           MPIF_Init
+#  define CALL_MPI_Init_thread    MPIF_Init_thread
 #  define CALL_MPI_Finalize       MPI_Finalize
 #  define CALL_MPI_Comm_dup       MPI_Comm_dup
 #  define CALL_MPI_Errhandler_set MPI_Errhandler_set
@@ -75,6 +76,7 @@
 #  endif
 
 #  define CALL_MPI_Init           MPIQ_Init
+#  define CALL_MPI_Init_thread    MPIQ_Init_thread
 #  define CALL_MPI_Finalize       MPIQ_Finalize
 #  define CALL_MPI_Comm_dup       MPIQ_Comm_dup
 #  define CALL_MPI_Errhandler_set MPIQ_Errhandler_set
@@ -96,6 +98,7 @@
 #  define CALL_MPI_Wtime          MPI_Wtime
 #elif defined _MG_MPI
 #  define CALL_MPI_Init           MPI_Init
+#  define CALL_MPI_Init_thread    MPI_Init_thread
 #  define CALL_MPI_Finalize       MPI_Finalize
 #  define CALL_MPI_Comm_dup       MPI_Comm_dup
 #  define CALL_MPI_Errhandler_set MPI_Errhandler_set

--- a/src/mg_utils.c
+++ b/src/mg_utils.c
@@ -54,8 +54,22 @@ int MG_Init ( int argc, char *argv[], InputParams *params )
 
 #if defined _MG_MPI
 
-   CALL_MPI_Init ( &argc, &argv);
-   MG_Assert ( MPI_SUCCESS == ierr, "CALL_MPI_Init" );
+   char *mpi_ts = getenv ( "MPI_TS" );
+   int required = MPI_THREAD_MULTIPLE;
+   int provided;
+   if ( mpi_ts && strcmp ( mpi_ts, "MPI_THREAD_SINGLE" ) == 0 ) {
+      required = MPI_THREAD_SINGLE;
+   } else if ( mpi_ts && strcmp ( mpi_ts, "MPI_THREAD_FUNNELED" ) == 0 ) {
+      required = MPI_THREAD_FUNNELED;
+   } else if ( mpi_ts && strcmp ( mpi_ts, "MPI_THREAD_SERIALIZED" ) == 0 ) {
+      required = MPI_THREAD_SERIALIZED;
+   } else if ( mpi_ts && strcmp ( mpi_ts, "MPI_THREAD_MULTIPLE" ) == 0 ) {
+      required = MPI_THREAD_MULTIPLE;
+   }
+
+   CALL_MPI_Init_thread ( &argc, &argv, required, &provided );
+   MG_Assert ( MPI_SUCCESS == ierr, "CALL_MPI_Init_thread" );
+   MG_Assert ( required == provided, "CALL_MPI_Init_thread" );
 
    ierr = CALL_MPI_Comm_dup ( MPI_COMM_WORLD, &MPI_COMM_MG );
    MG_Assert ( MPI_SUCCESS == ierr, "CALL_MPI_Comm_dup" );


### PR DESCRIPTION
By default, `MPI_THREAD_MULTIPLE` is set.  It is configured via an environmental
variable `MPI_TS` at runtime.
```
MPI_TS=MPI_THREAD_MULTIPLE ./miniGhost ...
```

With Argobots+MPICH, it is necessary to "run" under `numvars!=1`, `blks!=1`, and `-N>1`, though it fails the correctness check.
```
$ ABT_NUM_XSTREAMS=4 ABT_THREAD_STACKSIZE=32000 MPI_TS=MPI_THREAD_MULTIPLE ./mpiexec -N 2 -ppn=2 ./minighost --scaling MG_SCALING_WEAK --comm_method MG_COMM_METHOD_TASK_BLOCKS --block_order  MG_BLOCK_ORDER_RANDOM --nx 40 --ny 40 --nz 40 --blkxlen 10 --blkylen 10 --blkzlen 10 --numvars 10 --percent_sum 100 --numspikes 1 --numtsteps 20 --stencil MG_STENCIL_3D7PT --error_tol 8 --check_answer_freq 21 --npx 2 --npy 1 --npz 1   
 ========================================================================= 
 Mantevo miniGhost, task parallel (MPI) version. 
 2 MPI processes num_vars 10 num_blks = 64
 Applying 7 point stencil in 3 dimensions. 
 Blocking send / blocking recv. (MG_COMM_STRATEGY_SR) 
 Tags are SHARED for all messages between pairs of comm partners,
 i.e. compiled with -D_DONT_WORRY_ABOUT_TAGS.
 Random block decomposition strategy: 
 Global grid dimension = 80 x 40 x 40 
 Local grid dimension  = 40 x 40 x 40 
 block size            = 10 x 10 x 10 
 Number of variables = 10 
 (No extra work injected.) 
 20 time steps to be executed for each of 1 heat spikes. 
 6.07e-03 GBytes allocated per MPI rank, total 1.21e-02 GBytes. 
 Begin program execution. 
 ========================================================================= 
 ** Final correctness check FAILED. (10 variables showed errors) ** 
  ** Error for variable 1 is 1.98430279e-04, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 2 is 3.19902750e-05, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 3 is 2.46087323e-04, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 4 is 1.55112058e-04, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 5 is 1.67406542e-05, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 6 is 4.01927464e-04, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 7 is 3.53827087e-04, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 8 is 6.05066803e-04, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 9 is 4.54787420e-05, exceeding tolerance of 1.000000e-08. 
  ** Error for variable 10 is 7.82602668e-06, exceeding tolerance of 1.000000e-08.
```
Note without `MPI_TS=MPI_THREAD_MULTIPLE` it causes SEGV.